### PR TITLE
Fix error handling when outside git repos

### DIFF
--- a/deliver.sh
+++ b/deliver.sh
@@ -21,6 +21,15 @@ USECOLOR=true;
 [[ -t 1 ]] || USECOLOR=false;
 
 REPO_ROOT=`git rev-parse --git-dir 2> /dev/null` # for some reason, --show-toplevel returns nothing
+
+function exit_with_error
+	{
+	local code=$1
+	local msg="$2"
+	echo_red "$msg"
+	exit $code
+	}
+
 if [[ $? -gt 0 ]]; then
 	exit_with_error 1 "ERROR : not a git repo"
 fi
@@ -89,14 +98,6 @@ function exit_if_error
 		local msg="$2"
 		exit_with_error $code "$msg"
 	fi
-	}
-
-function exit_with_error
-	{
-	local code=$1
-	local msg="$2"
-	echo_red "$msg"
-	exit $code
 	}
 
 function exit_with_help


### PR DESCRIPTION
Currently running `git deliver` outside of a repo results in the following error message:

`/path/to/git-deliver/deliver.sh: line 25: exit_with_error: command not found`

Moved the exit_with_error function to exist before its first invocation.
