### PR TITLE
Don't try to multiplex SSH connections on cygwin or msysgit regardless of OpenSSH version

### DIFF
--- a/deliver_ssh_wrapper.sh
+++ b/deliver_ssh_wrapper.sh
@@ -31,14 +31,9 @@ if [[ $# == 0 ]]; then
 	exit
 fi
 
-## OpenSSH as included in the current msys install does not support
+## OpenSSH as included in the current msys or cygwin installs does not support
 ## multiplexing with privilege separation -> forget it
-if [[ "$OSTYPE" == "msys" ]] && [[ `ssh -V 2>&1 | cut -d, -f1` == "OpenSSH_4.6p1" ]]; then
-	exec ssh "$@"
-fi
-
-## Same with cygwin
-if [[ "$OSTYPE" == "cygwin" ]] && [[ `ssh -V 2>&1 | cut -d, -f1` == "OpenSSH_6.2p2" ]]; then
+if [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
 	exec ssh "$@"
 fi
 


### PR DESCRIPTION
Cygwin upgraded OpenSSH, but still no multiplexing in sight.
I think it would be safer to just assume multiplexing isn't available on windows, regardless of OpenSSH version.
