### PR TITLE
force push option

### DIFF
--- a/tests.sh
+++ b/tests.sh
@@ -543,6 +543,20 @@ testDeliverNotFastForwardSsh()
 	assertEquals 0 $?
 	}
 
+testDeliverNotFastForwardForcedSsh()
+	{
+	initWithSshOrigin
+	"$ROOT_DIR"/deliver.sh --init-remote --batch origin &> /dev/null
+	"$ROOT_DIR"/deliver.sh --batch origin master &> /dev/null
+	git reset master^
+	echo "asdsdf" >> a
+	git commit -am "new master"
+	A=`"$ROOT_DIR"/deliver.sh --batch --force origin master 2>&1`
+	assertEquals 0 $?
+	echo "$A" | grep "forced update"
+	assertEquals 0 $?
+	}
+
 testBasicDeliverMasterSsh()
 	{
 	initWithSshOrigin


### PR DESCRIPTION
Depending on your Git workflow, you may often be faced with "non-fast-forward" errors.

Let's say you have a *build* branch, used to merge several feature branches to build release-candidates. You might want to "rebuild" this branch to keep a clean git tree, instead of merging every feature fix.

It that case, you'll obviously get "non-fast-forward" errors when delivering this branch.

I propose adding a `--force` option that will cause force pushes to the bare remote repo.

Thix also fixes arnoo/git-deliver/issues/55
